### PR TITLE
[Cursor] Fix TypeError in view-selections when submission data is undefined

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -53,10 +53,20 @@ at view-selections.tsx:86:52
 
 ### Implementation Plan:
 
-1. Check if submission data exists before adding to menuListBuilder
-2. Only render menu items that have valid submission data
-3. Add appropriate error handling for missing submissions
+[X] Check if submission data exists before adding to menuListBuilder
+[X] Only render menu items that have valid submission data
+[X] Add appropriate error handling for missing submissions
+
+### Status: Complete ✅
+
+Fixed the issue by:
+1. Adding null check after fetching submission data (line 60)
+2. Adding defensive check with error logging in render (line 86-89)
+3. Created branch fix/view-selections-undefined-error
+4. Pushed changes to GitHub
 
 ### Notes:
 
 The bug happens because the code assumes all menus with submissions will have valid submission documents, but this isn't always the case. Need to add defensive checks.
+
+PR can be created at: https://github.com/sdjamaat/website/pull/new/fix/view-selections-undefined-error

--- a/.cursorrules
+++ b/.cursorrules
@@ -34,53 +34,29 @@ The goal is to help you maintain a big picture as well as the progress of the ta
 
 # Scratchpad
 
-## Current Task: Fix Safar 1447 Menu Display Issue
+## Current Task: Fix View Selections TypeError
 
 ### Problem:
 
-Safar 1447 menu is active in the database but not showing up on the user portal.
+User is getting a TypeError when viewing past selections:
+```
+Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'submittedBy')
+at view-selections.tsx:86:52
+```
 
-### Analysis Plan:
+### Analysis:
 
-[X] Investigate DateContext implementation to understand year vs databaseYear logic
-[X] Check how menus are queried in the FMB components
-[X] Identify where the bug is occurring (likely using wrong year for queries)
-[X] Fix the query to use databaseYear instead of year
-[X] Test the fix to ensure Safar 1447 menus appear
+[X] Located the error in view-selections.tsx at line 86
+[X] Issue: Code tries to access `submissionData.submittedBy.firstname` but `submissionData` is undefined
+[X] Root cause: When fetching submission data, if document doesn't exist, `familySubmission.data()` returns undefined
+[X] Fix: Add null checking before using submission data
 
-### Bug Found & Analysis:
+### Implementation Plan:
 
-**Issue 1 (FIXED):** In `view-selections.tsx` line 32 - was using `year` instead of `databaseYear`
-
-**Issue 2 (FIXED):** Cross-year transition logic missing in `submit-menu.js`
-
-- **WAS**: Only checking current databaseYear (1446) collection
-- **ISSUE**: Safar 1447 active in 1447 collection, but component only looked at 1446
-- **FIXED**: Added fallback logic to check actual year collection when in Moharram and no active menu found in databaseYear
-
-**Issue 3 (FIXED):** State not properly reset for new menus
-
-- **WAS**: `hasAlreadySubmitted` and `alreadySubmittedItemsDoc` not reset when loading new menu
-- **ISSUE**: Showing old submission data from previous menus when loading Safar 1447
-- **FIXED**: Added state reset logic before checking submissions for any new menu
-
-**Issue 4 (FIXED):** Submission saving to wrong database collection
-
-- **WAS**: Submission function using `databaseYear` (1446) for all submissions
-- **ISSUE**: Safar 1447 menu loads from 1447 collection but submissions tried to save to 1446 collection
-- **FIXED**: Added `activeMenuYear` state to track which year collection the active menu came from, use that for submissions
-
-### Status: Complete ✅
-
-All four issues have been fixed:
-
-1. `view-selections.tsx` now uses correct `databaseYear`
-2. `submit-menu.js` now handles cross-year transitions for Moharram → other months
-3. Component state properly resets when loading new menus
-4. Submissions now save to the correct database collection matching where the menu was loaded from
-
-Users should now be able to fully view and submit Safar 1447 menus successfully.
+1. Check if submission data exists before adding to menuListBuilder
+2. Only render menu items that have valid submission data
+3. Add appropriate error handling for missing submissions
 
 ### Notes:
 
-From lessons learned: Safar is the 2nd month of Hijri calendar. The DateContext provides both `year` (actual Hijri year) and `databaseYear` (correct year for database queries). Always use `databaseYear` for Firestore collection queries in FMB components.
+The bug happens because the code assumes all menus with submissions will have valid submission documents, but this isn't always the case. Need to add defensive checks.

--- a/src/components/dashboard/fmb/view-selections/view-selections.tsx
+++ b/src/components/dashboard/fmb/view-selections/view-selections.tsx
@@ -56,10 +56,13 @@ const ViewSelections = (props: ViewSelectionsProps) => {
         .get()) as firestore.DocumentSnapshot<FamilySubmissionData>
       const familySubmissionsDataForMenu = familySubmission.data()
 
-      menuListBuilder.push({
-        menuData: menuData,
-        submissionData: familySubmissionsDataForMenu,
-      })
+      // Only add to menuListBuilder if submission data exists
+      if (familySubmissionsDataForMenu) {
+        menuListBuilder.push({
+          menuData: menuData,
+          submissionData: familySubmissionsDataForMenu,
+        })
+      }
     }
     setMenuList(menuListBuilder)
     setIsLoading(false)
@@ -79,6 +82,11 @@ const ViewSelections = (props: ViewSelectionsProps) => {
             </Divider>
             {menuList.length > 0 &&
               menuList.map(({ menuData, submissionData }) => {
+                // Additional defensive check
+                if (!submissionData?.submittedBy) {
+                  console.error(`Missing submission data for menu ${menuData.displayMonthName}`)
+                  return null
+                }
                 return (
                   <ItemListDisplay
                     key={menuData.displayMonthName}


### PR DESCRIPTION
## Problem

Fixed a TypeError that occurs when viewing past selections:
```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'submittedBy')
at view-selections.tsx:86:52
```

## Root Cause

The error happens when `familySubmission.data()` returns `undefined` for documents that don't exist, but the code tries to access `submissionData.submittedBy.firstname` without checking if `submissionData` exists first.

## Solution

- Added null check after fetching submission data (line 60)
- Added defensive check with error logging in render method (lines 86-89)  
- Only render menu items that have valid submission data

## Testing

- Verified that past selections with valid data still display correctly
- Confirmed that missing submission documents no longer cause crashes
- Error logging helps with debugging if issues occur

This fix ensures the view-selections page is more robust when dealing with incomplete or missing submission data.
