### PR TITLE
Add per-item size restriction for user selection

### DIFF
--- a/src/components/dashboard/fmb/shared/item-list-display.tsx
+++ b/src/components/dashboard/fmb/shared/item-list-display.tsx
@@ -30,7 +30,12 @@ const ItemListDisplay = (props: ItemListDisplayProps) => {
                     if (!item.nothaali) {
                       return (
                         <div key={index} style={{ borderLeft: "1px solid gray", paddingLeft: "1rem" }}>
-                          <div style={{ fontSize: "1.2rem", paddingBottom: ".7rem" }}>{item.name}</div>
+                          <div style={{ fontSize: "1.2rem", paddingBottom: ".7rem" }}>
+                            {item.name}
+                            {item.sizeRestrictionEnabled && item.maxSize && (
+                              <span style={{ fontSize: "0.8rem", color: "#faad14", marginLeft: "0.5rem" }}>(max: {item.maxSize})</span>
+                            )}
+                          </div>
                           <p style={{ marginBottom: ".2rem", marginTop: "-.5rem", color: "gray" }}>
                             {moment(item.date, "MM-DD-YYYY").format("dddd, MMMM Do YYYY")}
                           </p>

--- a/src/components/dashboard/fmb/submit-menu/collect-item-info/review-selections.tsx
+++ b/src/components/dashboard/fmb/submit-menu/collect-item-info/review-selections.tsx
@@ -34,7 +34,12 @@ const ReviewSelections = ({ setPanel, items, selections, distDateMap, submitSele
                   </p>
                 )}
                 <div style={{ borderLeft: "1px solid gray", paddingLeft: "1rem" }}>
-                  <div style={{ fontSize: "1.2rem", paddingBottom: ".7rem" }}>{item.name}</div>
+                  <div style={{ fontSize: "1.2rem", paddingBottom: ".7rem" }}>
+                    {item.name}
+                    {item.sizeRestrictionEnabled && item.maxSize && (
+                      <span style={{ fontSize: "0.8rem", color: "#faad14", marginLeft: "0.5rem" }}>(max: {item.maxSize})</span>
+                    )}
+                  </div>
                   {!hasGroupedSelectionByDistDate && (
                     <p style={{ marginBottom: ".2rem", marginTop: "-.5rem", color: "gray" }}>
                       {moment(item.date, "MM-DD-YYYY").format("dddd, MMMM Do YYYY")}

--- a/src/components/dashboard/fmb/submit-menu/collect-item-info/select-items.tsx
+++ b/src/components/dashboard/fmb/submit-menu/collect-item-info/select-items.tsx
@@ -157,7 +157,12 @@ const SelectItems = ({ setPanel, items, values, setValues }: SelectItemsProps) =
                     Distribution on {moment(distDate, "MM-DD-YYYY").format("dddd, MMMM Do YYYY")}
                   </p>
                 )}
-                <div style={{ fontSize: "1.2rem", paddingBottom: ".5rem" }}>{item.name}</div>
+                <div style={{ fontSize: "1.2rem", paddingBottom: ".5rem" }}>
+                  {item.name}
+                  {item.sizeRestrictionEnabled && item.maxSize && (
+                    <span style={{ fontSize: "0.8rem", color: "#faad14", marginLeft: "0.5rem" }}>(max: {item.maxSize})</span>
+                  )}
+                </div>
                 {groupToggle === "calendar-date" && (
                   <p style={{ marginBottom: ".5rem", marginTop: "-.5rem", color: "gray" }}>
                     {moment(item.date, "MM-DD-YYYY").format("dddd, MMMM Do YYYY")}

--- a/src/components/dashboard/fmb/submit-menu/collect-item-info/select-items.tsx
+++ b/src/components/dashboard/fmb/submit-menu/collect-item-info/select-items.tsx
@@ -11,6 +11,7 @@ import {
   ThaaliItem,
   ValuesFromSelectItems,
 } from "../../../../../types/typings"
+import { getEffectiveMaxSize, canSelectSize } from "../../../../../utils/thaali-sizes"
 import moment from "moment"
 const { Option } = Select
 
@@ -34,13 +35,24 @@ const SelectItems = ({ setPanel, items, values, setValues }: SelectItemsProps) =
   const { currUser } = useContext(AuthContext)
   const userFamilyThaaliSize = currUser.family.fmb.thaaliSize
 
-  const canSelectGivenThaaliSize = (thaaliSize: SelectToggleType) => {
-    if (userFamilyThaaliSize === "Grand" && (thaaliSize === "Grand" || thaaliSize === "Full" || thaaliSize === "Half" || thaaliSize === "Quarter")) return true
-    if (userFamilyThaaliSize === "Full" && (thaaliSize === "Full" || thaaliSize === "Half" || thaaliSize === "Quarter")) return true
-    if (userFamilyThaaliSize === "Half" && (thaaliSize === "Half" || thaaliSize === "Quarter")) return true
-    if (userFamilyThaaliSize === "Quarter" && thaaliSize === "Quarter") return true
-    return false
+  const canSelectGivenThaaliSize = (thaaliSize: SelectToggleType, itemMaxSize?: string | null) => {
+    if (thaaliSize === "No Thaali" || thaaliSize === "individual") return true
+    const effectiveMax = getEffectiveMaxSize(userFamilyThaaliSize, itemMaxSize)
+    return canSelectSize(thaaliSize, effectiveMax)
   }
+
+  // For the bulk toggle, compute the most restrictive max across all non-nothaali items
+  const getMostRestrictiveMax = (): string => {
+    let mostRestrictive = userFamilyThaaliSize
+    for (const item of items) {
+      if (!item.nothaali && item.sizeRestrictionEnabled && item.maxSize) {
+        mostRestrictive = getEffectiveMaxSize(mostRestrictive, item.maxSize)
+      }
+    }
+    return mostRestrictive
+  }
+
+  const bulkMaxSize = getMostRestrictiveMax()
 
   const onFinish = (formValues: FormValues) => {
     setValues({ ...formValues, distDateMap })
@@ -55,8 +67,18 @@ const SelectItems = ({ setPanel, items, values, setValues }: SelectItemsProps) =
     const toggleValue = event.target.value as SelectToggleType
     if (toggleValue !== "individual") {
       let newItemPreferences: FormValues = selectItemsForm.getFieldsValue()
-      for (let key in newItemPreferences.items) {
-        (newItemPreferences.items as any)[key] = toggleValue
+      for (const item of items) {
+        if (!item.nothaali && newItemPreferences.items) {
+          if (toggleValue === "No Thaali") {
+            (newItemPreferences.items as any)[item.id] = toggleValue
+          } else {
+            // Auto-clamp to item's effective max if the selected size exceeds it
+            const itemMax = item.sizeRestrictionEnabled ? item.maxSize : undefined
+            const effectiveMax = getEffectiveMaxSize(userFamilyThaaliSize, itemMax)
+            const allowed = canSelectSize(toggleValue, effectiveMax)
+            ;(newItemPreferences.items as any)[item.id] = allowed ? toggleValue : effectiveMax
+          }
+        }
       }
       selectItemsForm.setFieldsValue(newItemPreferences)
     }
@@ -125,10 +147,10 @@ const SelectItems = ({ setPanel, items, values, setValues }: SelectItemsProps) =
         <Form.Item name="select-toggle" label="Toggle size (for all items)">
           <Radio.Group onChange={onSelectToggleChange}>
             <Radio value="individual">Individual selection</Radio>
-            {canSelectGivenThaaliSize("Grand") && <Radio value="Grand">Grand</Radio>}
-            {canSelectGivenThaaliSize("Full") && <Radio value="Full">Full</Radio>}
-            {canSelectGivenThaaliSize("Half") && <Radio value="Half">Half</Radio>}
-            {canSelectGivenThaaliSize("Quarter") && <Radio value="Quarter">Quarter</Radio>}
+            {canSelectSize("Grand", bulkMaxSize) && <Radio value="Grand">Grand</Radio>}
+            {canSelectSize("Full", bulkMaxSize) && <Radio value="Full">Full</Radio>}
+            {canSelectSize("Half", bulkMaxSize) && <Radio value="Half">Half</Radio>}
+            {canSelectSize("Quarter", bulkMaxSize) && <Radio value="Quarter">Quarter</Radio>}
             <Radio value="No Thaali">No Thaali</Radio>
           </Radio.Group>
         </Form.Item>
@@ -155,10 +177,10 @@ const SelectItems = ({ setPanel, items, values, setValues }: SelectItemsProps) =
                 )}
                 <Form.Item key={index} name={["items", item.id]} rules={[{ required: true, message: "Please input thaali size" }]}>
                   <Select style={{ width: "100%" }}>
-                    {canSelectGivenThaaliSize("Grand") && <Option value="Grand">Grand</Option>}
-                    {canSelectGivenThaaliSize("Full") && <Option value="Full">Full</Option>}
-                    {canSelectGivenThaaliSize("Half") && <Option value="Half">Half</Option>}
-                    {canSelectGivenThaaliSize("Quarter") && <Option value="Quarter">Quarter</Option>}
+                    {canSelectGivenThaaliSize("Grand", item.sizeRestrictionEnabled ? item.maxSize : undefined) && <Option value="Grand">Grand</Option>}
+                    {canSelectGivenThaaliSize("Full", item.sizeRestrictionEnabled ? item.maxSize : undefined) && <Option value="Full">Full</Option>}
+                    {canSelectGivenThaaliSize("Half", item.sizeRestrictionEnabled ? item.maxSize : undefined) && <Option value="Half">Half</Option>}
+                    {canSelectGivenThaaliSize("Quarter", item.sizeRestrictionEnabled ? item.maxSize : undefined) && <Option value="Quarter">Quarter</Option>}
                     <Option value="No Thaali">No Thaali</Option>
                   </Select>
                 </Form.Item>

--- a/src/components/dashboard/fmb/submit-menu/collect-item-info/select-items.tsx
+++ b/src/components/dashboard/fmb/submit-menu/collect-item-info/select-items.tsx
@@ -41,18 +41,6 @@ const SelectItems = ({ setPanel, items, values, setValues }: SelectItemsProps) =
     return canSelectSize(thaaliSize, effectiveMax)
   }
 
-  // For the bulk toggle, compute the most restrictive max across all non-nothaali items
-  const getMostRestrictiveMax = (): string => {
-    let mostRestrictive = userFamilyThaaliSize
-    for (const item of items) {
-      if (!item.nothaali && item.sizeRestrictionEnabled && item.maxSize) {
-        mostRestrictive = getEffectiveMaxSize(mostRestrictive, item.maxSize)
-      }
-    }
-    return mostRestrictive
-  }
-
-  const bulkMaxSize = getMostRestrictiveMax()
 
   const onFinish = (formValues: FormValues) => {
     setValues({ ...formValues, distDateMap })
@@ -147,10 +135,10 @@ const SelectItems = ({ setPanel, items, values, setValues }: SelectItemsProps) =
         <Form.Item name="select-toggle" label="Toggle size (for all items)">
           <Radio.Group onChange={onSelectToggleChange}>
             <Radio value="individual">Individual selection</Radio>
-            {canSelectSize("Grand", bulkMaxSize) && <Radio value="Grand">Grand</Radio>}
-            {canSelectSize("Full", bulkMaxSize) && <Radio value="Full">Full</Radio>}
-            {canSelectSize("Half", bulkMaxSize) && <Radio value="Half">Half</Radio>}
-            {canSelectSize("Quarter", bulkMaxSize) && <Radio value="Quarter">Quarter</Radio>}
+            {canSelectGivenThaaliSize("Grand") && <Radio value="Grand">Grand</Radio>}
+            {canSelectGivenThaaliSize("Full") && <Radio value="Full">Full</Radio>}
+            {canSelectGivenThaaliSize("Half") && <Radio value="Half">Half</Radio>}
+            {canSelectGivenThaaliSize("Quarter") && <Radio value="Quarter">Quarter</Radio>}
             <Radio value="No Thaali">No Thaali</Radio>
           </Radio.Group>
         </Form.Item>

--- a/src/types/typings.d.ts
+++ b/src/types/typings.d.ts
@@ -21,6 +21,8 @@ export interface ThaaliItem {
   nothaali: boolean
   date: string
   name: string
+  sizeRestrictionEnabled?: boolean
+  maxSize?: string
 }
 
 export interface MenuData {

--- a/src/utils/thaali-sizes.ts
+++ b/src/utils/thaali-sizes.ts
@@ -1,0 +1,30 @@
+const SIZE_HIERARCHY: Record<string, number> = {
+  Grand: 4,
+  Full: 3,
+  Half: 2,
+  Quarter: 1,
+}
+
+export const ALL_SIZES = ["Grand", "Full", "Half", "Quarter"] as const
+
+export const getEffectiveMaxSize = (
+  familyMaxSize: string,
+  itemMaxSize?: string | null
+): string => {
+  if (!itemMaxSize) return familyMaxSize
+  const familyRank = SIZE_HIERARCHY[familyMaxSize] ?? 4
+  const itemRank = SIZE_HIERARCHY[itemMaxSize] ?? 4
+  return familyRank <= itemRank ? familyMaxSize : itemMaxSize
+}
+
+export const getAllowedSizes = (effectiveMaxSize: string): string[] => {
+  const maxRank = SIZE_HIERARCHY[effectiveMaxSize] ?? 4
+  return ALL_SIZES.filter((size) => SIZE_HIERARCHY[size] <= maxRank)
+}
+
+export const canSelectSize = (size: string, effectiveMaxSize: string): boolean => {
+  const sizeRank = SIZE_HIERARCHY[size]
+  const maxRank = SIZE_HIERARCHY[effectiveMaxSize]
+  if (sizeRank === undefined || maxRank === undefined) return false
+  return sizeRank <= maxRank
+}


### PR DESCRIPTION
## Summary
- Extends user-facing menu selection to respect item-level max size restrictions set by admins
- The effective max for each item is the more restrictive of the family's thaali size and the item's max size

## Changes
- **`src/utils/thaali-sizes.ts`** — new utility with `getEffectiveMaxSize()`, `canSelectSize()`
- **`src/types/typings.d.ts`** — adds optional `sizeRestrictionEnabled` and `maxSize` to `ThaaliItem`
- **`select-items.tsx`** — per-item dropdowns only show sizes up to that item's effective max; bulk toggle still shows all family-allowed sizes but auto-clamps restricted items silently

## Design decisions
- Bulk toggle shows all sizes the family is allowed — no options hidden
- When a bulk size exceeds an item's max, that item gets silently set to its effective max
- Backward compatible: items without the new fields behave exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)