### PR TITLE
Hotfix: login broken by autofill (auth/wrong-password)

### DIFF
--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -130,7 +130,7 @@ const LoginForm = () => {
               { type: "email", message: "Email is not valid" },
             ]}
           >
-            <Input autoComplete="email" inputMode="email" />
+            <Input inputMode="email" />
           </Form.Item>
 
           <Form.Item
@@ -138,7 +138,7 @@ const LoginForm = () => {
             name="password"
             rules={[{ required: true, message: "Please input your password" }]}
           >
-            <Input.Password autoComplete="current-password" />
+            <Input.Password />
           </Form.Item>
 
           <Form.Item>


### PR DESCRIPTION
## Problem
After #40 merged, **all accounts** fail login on prod with `Firebase: Error (auth/wrong-password)`.

## Root cause
#40 added `autoComplete="current-password"` to the login password field. That let the browser autofill a **stale saved password** over what the user types; antd's form submitted that value → `auth/wrong-password` for everyone. `wrong-password` (not `user-not-found`/`missing-password`) confirms a non-empty but incorrect password reached Firebase.

Ruled out via the Firebase API:
- Project is correct (`sdj-production`).
- Accounts exist; `users` + `families` docs are healthy and complete.
- Firestore rules unchanged (original permissive set).
- Only login-touching change in #40 was the `autoComplete` attribute.

## Fix
Remove `autoComplete` from the login email + password fields, restoring the pre-#40 behavior where the typed value is always what's submitted. Keeps `inputMode="email"` (affects the mobile keyboard only, not autofill).

## Test plan
- [ ] Merge → Netlify redeploys → log in on prod with a known-good account → succeeds.
- [ ] No browser-autofilled password overrides the typed value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)