### PR TITLE
Fix login submit race and mobile manage-family layout

### DIFF
--- a/src/components/dashboard/profile/profile.tsx
+++ b/src/components/dashboard/profile/profile.tsx
@@ -14,6 +14,7 @@ import {
   Select,
   Popconfirm,
   Tooltip,
+  Grid,
 } from "antd"
 import { Row, Col } from "react-bootstrap"
 import styled from "styled-components"
@@ -58,6 +59,8 @@ const placeholderName = (index: number) => `Member ${index + 2}`
 const Profile = () => {
   const { currUser } = useContext(AuthContext)
   const isHead = currUser.family?.head?.uid === currUser.uid
+  const screens = Grid.useBreakpoint()
+  const isMobile = !screens.sm
 
   const [inviteLinks, setInviteLinks] = useState<Record<number, string>>({})
   const [generating, setGenerating] = useState<number | null>(null)
@@ -349,7 +352,7 @@ const Profile = () => {
     }
 
     return (
-      <List.Item key={index} actions={actions}>
+      <List.Item key={index} actions={actions.length ? actions : undefined}>
         <List.Item.Meta
           avatar={
             <div className="member-avatar">
@@ -497,10 +500,13 @@ const Profile = () => {
                   extra={
                     <Button
                       type="primary"
+                      shape={isMobile ? "circle" : "default"}
                       icon={<UserAddOutlined />}
                       onClick={() => setAddOpen(true)}
+                      aria-label="Add member"
+                      title="Add member"
                     >
-                      Add member
+                      {isMobile ? null : "Add member"}
                     </Button>
                   }
                   style={{ marginTop: "1.5rem" }}
@@ -757,14 +763,23 @@ const ProfileWrapper = styled.div`
     .manage-section .ant-card-body {
       padding: 0.75rem;
     }
+    /* antd's .ant-list-item is flex + justify-content: space-between, which in a
+       column layout pushes the buttons to the bottom of a stretched row. Drop the
+       flex entirely on mobile so the meta and actions just stack naturally. */
     .manage-section .ant-list-item {
-      flex-direction: column;
-      align-items: stretch;
-      gap: 0.5rem;
-      padding: 0.75rem 0;
+      display: block;
+      padding: 0.6rem 0;
     }
     .manage-section .ant-list-item-meta {
-      margin-bottom: 0 !important;
+      margin-bottom: 0.5rem !important;
+    }
+    .manage-section .ant-list-item-meta-title {
+      margin-bottom: 0.1rem;
+      line-height: 1.3;
+    }
+    /* registered members have no actions — don't reserve space for an empty list */
+    .manage-section .ant-list-item-action:empty {
+      display: none;
     }
     .manage-section .ant-list-item-action {
       margin-left: 0 !important;

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -72,38 +72,35 @@ const LoginForm = () => {
   const [tab] = useQueryParam("tab", "")
 
   const onSubmit = async (values: any) => {
-    if (isSubmitting) {
-      try {
-        const response = await signInWithEmailAndPassword(auth, values.email, values.password)
-        if (response.user.uid) {
-          const isUser = await getAndSetUserInformation(
-            response.user.uid,
-            localEncryptedStore
-          )
-          if (isUser) {
-            setIsLoggedIn(true)
-            setCurrUser(localEncryptedStore.get("authUser"))
-            if (path) {
-              if (tab) {
-                navigate(`${path}?tab=${tab}`)
-              } else {
-                navigate(`${path}`)
-              }
+    setIsSubmitting(true)
+    try {
+      const response = await signInWithEmailAndPassword(auth, values.email, values.password)
+      if (response.user.uid) {
+        const isUser = await getAndSetUserInformation(
+          response.user.uid,
+          localEncryptedStore
+        )
+        if (isUser) {
+          setIsLoggedIn(true)
+          setCurrUser(localEncryptedStore.get("authUser"))
+          if (path) {
+            if (tab) {
+              navigate(`${path}?tab=${tab}`)
             } else {
-              navigate("/auth/dashboard?tab=profile")
+              navigate(`${path}`)
             }
           } else {
-            throw { message: "Unauthorized" }
+            navigate("/auth/dashboard?tab=profile")
           }
         } else {
-          CustomMessage("error", "Something went wrong while logging in")
+          throw { message: "Unauthorized" }
         }
-      } catch (error: any) {
-        CustomMessage("error", error.message)
-      } finally {
-        setIsSubmitting(false)
+      } else {
+        CustomMessage("error", "Something went wrong while logging in")
       }
-    } else {
+    } catch (error: any) {
+      CustomMessage("error", error.message)
+    } finally {
       setIsSubmitting(false)
     }
   }
@@ -146,7 +143,7 @@ const LoginForm = () => {
               type="primary"
               className="submit mod-btn"
               htmlType="submit"
-              onClick={() => setIsSubmitting(true)}
+              loading={isSubmitting}
             >
               Submit
             </Button>


### PR DESCRIPTION
## Summary
Two user-reported bugs in the web app:

### 1. Login fails on first attempt, works after refresh
The Submit button set `isSubmitting` via `onClick` while simultaneously submitting the form, and `onSubmit` gated the actual sign-in behind `if (isSubmitting)` — read from a **stale closure**. The sign-in only ran if React happened to re-render before antd's async validation called `onFinish`. On a cold page load the timing lost the race, so the first submit silently did nothing and only a page refresh "fixed" it.

**Fix:** run the sign-in directly in `onSubmit` (`setIsSubmitting(true)` at start, `false` in `finally`) and drive the spinner via the button's `loading` prop. This is in addition to the earlier autofill fix (#41).

### 2. Manage Family on mobile: huge gap + oversized button
antd's `.ant-list-item` is `display: flex; justify-content: space-between`. Forcing a column layout made it distribute the row's vertical space, pushing the action buttons to the bottom of a stretched row — the large white band on mobile.

**Fix:**
- Use a plain `display: block` layout for the member rows on mobile so meta and actions stack naturally.
- Skip the empty action list for registered members (no buttons → no reserved space).
- Render the **Add member** button as an icon-only circle on mobile (full label on larger screens).

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Log in from a cold page load — succeeds on the first attempt
- [ ] Profile → Manage Family on a narrow viewport — member rows are compact, no large gap; Add member is an icon on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)