### PR TITLE
Lay out mobile manage-family action buttons as a 50/25/25 row

### DIFF
--- a/src/components/dashboard/profile/profile.tsx
+++ b/src/components/dashboard/profile/profile.tsx
@@ -771,7 +771,7 @@ const ProfileWrapper = styled.div`
       padding: 0.6rem 0;
     }
     .manage-section .ant-list-item-meta {
-      margin-bottom: 0.5rem !important;
+      margin-bottom: 0.25rem !important;
     }
     .manage-section .ant-list-item-meta-title {
       margin-bottom: 0.1rem;
@@ -781,16 +781,27 @@ const ProfileWrapper = styled.div`
     .manage-section .ant-list-item-action:empty {
       display: none;
     }
+    /* full-width button row: Invite 50%, edit/delete 25% each */
     .manage-section .ant-list-item-action {
       margin-left: 0 !important;
-      margin-top: 0;
+      margin-top: 0.85rem;
       display: flex;
-      flex-wrap: wrap;
+      width: 100%;
       gap: 0.4rem;
     }
     .manage-section .ant-list-item-action > li {
       padding: 0;
       margin: 0;
+    }
+    .manage-section .ant-list-item-action > li:nth-child(1) {
+      flex: 2 1 0;
+    }
+    .manage-section .ant-list-item-action > li:nth-child(2),
+    .manage-section .ant-list-item-action > li:nth-child(3) {
+      flex: 1 1 0;
+    }
+    .manage-section .ant-list-item-action > li .ant-btn {
+      width: 100%;
     }
     .manage-section .ant-list-item-action > li .ant-list-item-action-split {
       display: none;


### PR DESCRIPTION
## Summary
Follow-up styling tweak to the mobile Manage Family member rows (builds on #42).

- The action buttons now span the full width of the row on mobile: **Invite 50%**, **edit 25%**, **delete 25%**, with each button filling its cell instead of hugging its content.
- Added more top spacing between the button row and the "Send an invite link…" description so the row reads as a distinct block.

## Notes
- Base is `fix/login-race-and-mobile-family` (PR #42) since both touch the same CSS block; GitHub will retarget this to `main` once #42 merges.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Profile → Manage Family on a narrow viewport — Invite is half-width, edit/delete a quarter each, clear gap above the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)